### PR TITLE
Fix bug of background in SnapNumbersPickerView

### DIFF
--- a/Sources/SnapCollection/UIKit/SnapNumbersPickerView/SnapNumbersPickerView.swift
+++ b/Sources/SnapCollection/UIKit/SnapNumbersPickerView/SnapNumbersPickerView.swift
@@ -87,6 +87,7 @@ public final class SnapNumbersPickerView: SnapCollectionView, UICollectionViewDa
     // MARK: - Private Methods
     
     private func setupCollectionView() {
+        backgroundColor = .clear
         dataSource = self
         pickerDelegate = self
         register(


### PR DESCRIPTION
После запуска на iPhone вылез такой background, в симуляторе не отображало. Исправил.
![image](https://github.com/izyumkin/SnapCollection/assets/103596015/f9162c46-8579-4b64-8d9d-14c8787d5b5a)
